### PR TITLE
Rename findActivateByEmail to findActiveByEmail

### DIFF
--- a/src/main/java/com/soompyo/server/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/soompyo/server/global/security/CustomUserDetailsService.java
@@ -20,7 +20,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User user = userRepository.findActivateByEmail(username)
+        User user = userRepository.findActiveByEmail(username)
             .orElseThrow(() -> new UsernameNotFoundException(username));
 
         List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()));

--- a/src/main/java/com/soompyo/server/user/repository/UserRepository.java
+++ b/src/main/java/com/soompyo/server/user/repository/UserRepository.java
@@ -15,6 +15,6 @@ public interface UserRepository {
 
     void deleteAll();
 
-    Optional<User> findActivateByEmail(String email);
+    Optional<User> findActiveByEmail(String email);
 
 }

--- a/src/main/java/com/soompyo/server/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/soompyo/server/user/repository/UserRepositoryImpl.java
@@ -31,7 +31,7 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
-    public Optional<User> findActivateByEmail(String email) {
+    public Optional<User> findActiveByEmail(String email) {
         return userJpaRepository.findByEmailAndStatus(email, UserStatus.ACTIVE);
     }
 

--- a/src/main/java/com/soompyo/server/user/service/UserService.java
+++ b/src/main/java/com/soompyo/server/user/service/UserService.java
@@ -50,7 +50,7 @@ public class UserService {
 
     @Transactional
     public UserLoginResponseDto login(UserLoginRequestDto dto) {
-        User findedUser = userRepository.findActivateByEmail(dto.email())
+        User findedUser = userRepository.findActiveByEmail(dto.email())
             .orElseThrow(UserLogInInformationMismatchException::new);
 
         if (!isPasswordMatch(dto.password(), findedUser.getPassword())) {
@@ -80,18 +80,18 @@ public class UserService {
 
     @Transactional
     public void softDeleteUser(String email) {
-        User findedUser = userRepository.findActivateByEmail(email).orElseThrow(UserNotFoundException::new);
+        User findedUser = userRepository.findActiveByEmail(email).orElseThrow(UserNotFoundException::new);
         findedUser.softDelete();
     }
 
     public UserDetailResponseDto getUserByEmail(String username) {
-        User findedUser = userRepository.findActivateByEmail(username).orElseThrow(UserNotFoundException::new);
+        User findedUser = userRepository.findActiveByEmail(username).orElseThrow(UserNotFoundException::new);
         return userMapper.toUserDetailDto(findedUser);
     }
 
     @Transactional
     public void updateUserPassword(String email, UserPasswordUpdateRequestDto dto) {
-        User findedUser = userRepository.findActivateByEmail(email).orElseThrow(UserNotFoundException::new);
+        User findedUser = userRepository.findActiveByEmail(email).orElseThrow(UserNotFoundException::new);
         if (!isPasswordMatch(dto.currentPassword(), findedUser.getPassword())) {
             throw new UserPasswordMismatchException();
         } else if (isPasswordMatch(dto.newPassword(), findedUser.getPassword())) {

--- a/src/test/java/com/soompyo/server/user/integrationtest/HttpUpdateTest.java
+++ b/src/test/java/com/soompyo/server/user/integrationtest/HttpUpdateTest.java
@@ -45,7 +45,7 @@ class HttpUpdateTest {
         ResponseEntity<Void> response = fixture.client()
             .exchange("/api/v1/users/me/password", HttpMethod.PATCH, new HttpEntity<>(updateDto), Void.class);
 
-        User updatedUser = userRepository.findActivateByEmail(email).orElseThrow();
+        User updatedUser = userRepository.findActiveByEmail(email).orElseThrow();
 
         // Assert
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);


### PR DESCRIPTION
## Summary
- Rename `findActivateByEmail` to `findActiveByEmail` in repositories, services, and security layer
- Update references in tests to use new method name

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68b8f0e3e7d483319dfc13aaf34c2b81