### PR TITLE
JWT 토큰의 권한 관련 필터 로직 수정

### DIFF
--- a/src/main/java/com/soompyo/server/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/soompyo/server/global/security/JwtAuthenticationFilter.java
@@ -1,8 +1,10 @@
 package com.soompyo.server.global.security;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
+import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -23,7 +25,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws
+    protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
+        @NonNull FilterChain chain) throws
         ServletException,
         IOException {
         String auth = request.getHeader("Authorization");
@@ -32,9 +35,23 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 String token = auth.substring(7);
                 Jws<Claims> claims = provider.parseAndValidate(token);
                 String email = claims.getPayload().get("email", String.class);
-                String role = claims.getPayload().get("role", String.class);
 
-                List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_" + role));
+                Object rolesObj = claims.getPayload().get("roles");
+                List<SimpleGrantedAuthority> authorities;
+
+                switch (rolesObj) {
+                    case List<?> list -> authorities = list.stream()
+                        .map(Object::toString)
+                        .map(SimpleGrantedAuthority::new)
+                        .toList();
+                    case String str -> authorities = Arrays.stream(str.split(","))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .map(SimpleGrantedAuthority::new)
+                        .toList();
+                    default -> authorities = List.of();
+                }
+
                 UsernamePasswordAuthenticationToken principal = new UsernamePasswordAuthenticationToken(email, null,
                     authorities);
                 SecurityContextHolder.getContext().setAuthentication(principal);


### PR DESCRIPTION
## 개요
- JWT 토큰 `roles` 클레임이 문자열이든 리스트든 권한으로 잘 풀리도록 필터 로직 정리했어요.

## 변경 사항
- `roles` 값을 바로 꺼낸 뒤 타입에 맞춰 `SimpleGrantedAuthority` 리스트로 매핑하도록 분기했습니다.
- 문자열 기반 `roles`는 콤마 기준으로 잘라서 공백 제거 후 권한으로 변환하게 했습니다.
- `OncePerRequestFilter`에서 요구하는 `@NonNullApi` 맞추려고 `doFilterInternal` 파라미터에 `@NonNull` 붙였습니다.

## 참고 사항
- API 스펙 변화는 없고, JWT 발급 시 `roles`를 리스트나 콤마 구분 문자열 형태로 유지하면 됩니다.