### PR TITLE
fix: JWT 권한 정합성 보완 및 일기 테스트 정리

### DIFF
--- a/src/main/java/com/soompyo/server/diary/domain/Diary.java
+++ b/src/main/java/com/soompyo/server/diary/domain/Diary.java
@@ -1,0 +1,46 @@
+package com.soompyo.server.diary.domain;
+
+import com.soompyo.server.global.domain.BaseTimeEntity;
+import com.soompyo.server.user.domain.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "Diary", indexes = {@Index(name = "idx_diary_user_id", columnList = "user_id")})
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Diary extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    @Column(nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    private DiaryEmotion emotion;
+}

--- a/src/main/java/com/soompyo/server/diary/domain/DiaryEmotion.java
+++ b/src/main/java/com/soompyo/server/diary/domain/DiaryEmotion.java
@@ -1,0 +1,5 @@
+package com.soompyo.server.diary.domain;
+
+public enum DiaryEmotion {
+    HAPPY, SAD, ANGRY, SURPRISED, NEUTRAL
+}

--- a/src/main/java/com/soompyo/server/global/response/ApiResponse.java
+++ b/src/main/java/com/soompyo/server/global/response/ApiResponse.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindException;
 
 import com.soompyo.server.global.exception.BusinessException;
+import com.soompyo.server.global.exception.userexception.UserLogInInformationMismatchException;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -47,7 +48,8 @@ public class ApiResponse<T> {
     }
 
     public static ApiResponse<Void> credentialFail() {
-        HttpStatus unauthorized = HttpStatus.UNAUTHORIZED;
-        return new ApiResponse<>(null, unauthorized.value(), "MEMBER-403", "사용자의 아이디 또는 비밀번호가 일치하지 않습니다.");
+        UserLogInInformationMismatchException exception = new UserLogInInformationMismatchException();
+        return new ApiResponse<>(null, exception.getHttpStatus().value(), exception.getErrorCode(),
+            exception.getMessage());
     }
 }

--- a/src/main/java/com/soompyo/server/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/soompyo/server/global/security/JwtAuthenticationFilter.java
@@ -32,9 +32,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 String token = auth.substring(7);
                 Jws<Claims> claims = provider.parseAndValidate(token);
                 String email = claims.getPayload().get("email", String.class);
-                String role = claims.getPayload().get("role", String.class);
+                @SuppressWarnings("unchecked")
+                List<String> roles = claims.getPayload().get("roles", List.class);
 
-                List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_" + role));
+                List<SimpleGrantedAuthority> authorities = roles == null
+                    ? List.of()
+                    : roles.stream()
+                        .map(SimpleGrantedAuthority::new)
+                        .toList();
                 UsernamePasswordAuthenticationToken principal = new UsernamePasswordAuthenticationToken(email, null,
                     authorities);
                 SecurityContextHolder.getContext().setAuthentication(principal);

--- a/src/test/java/com/soompyo/server/ApiTest.java
+++ b/src/test/java/com/soompyo/server/ApiTest.java
@@ -1,4 +1,4 @@
-package com.soompyo.server.user;
+package com.soompyo.server;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -7,12 +7,9 @@ import java.lang.annotation.Target;
 
 import org.springframework.boot.test.context.SpringBootTest;
 
-import com.soompyo.server.FixtureConfiguration;
-import com.soompyo.server.ServerApplication;
-
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @SpringBootTest(classes = {ServerApplication.class,
     FixtureConfiguration.class}, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public @interface UserApiTest {
+public @interface ApiTest {
 }

--- a/src/test/java/com/soompyo/server/FixtureConfiguration.java
+++ b/src/test/java/com/soompyo/server/FixtureConfiguration.java
@@ -4,9 +4,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Scope;
 import org.springframework.core.env.Environment;
 
-import com.soompyo.server.user.repository.UserRepository;
-
+import com.soompyo.server.diary.DiaryApiFixture;
+import com.soompyo.server.diary.repository.DiaryRepository;
+import com.soompyo.server.global.security.JwtTokenProvider;
+import com.soompyo.server.support.TestAuthSupport;
 import com.soompyo.server.user.UserApiFixture;
+import com.soompyo.server.user.repository.UserRepository;
+import com.soompyo.server.user.service.AuthService;
 
 public class FixtureConfiguration {
 
@@ -17,5 +21,24 @@ public class FixtureConfiguration {
         UserRepository userRepository
     ) {
         return UserApiFixture.create(environment, userRepository);
+    }
+
+    @Bean
+    TestAuthSupport testAuthSupport(
+        AuthService authService,
+        UserRepository userRepository,
+        JwtTokenProvider jwtTokenProvider
+    ) {
+        return new TestAuthSupport(authService, userRepository, jwtTokenProvider);
+    }
+
+    @Bean
+    @Scope("prototype")
+    DiaryApiFixture diaryApiFixture(
+        Environment environment,
+        DiaryRepository diaryRepository,
+        TestAuthSupport testAuthSupport
+    ) {
+        return DiaryApiFixture.create(environment, diaryRepository, testAuthSupport);
     }
 }

--- a/src/test/java/com/soompyo/server/diary/DiaryApiFixture.java
+++ b/src/test/java/com/soompyo/server/diary/DiaryApiFixture.java
@@ -1,0 +1,36 @@
+package com.soompyo.server.diary;
+
+import org.springframework.boot.test.web.client.LocalHostUriTemplateHandler;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.core.env.Environment;
+
+import com.soompyo.server.diary.repository.DiaryRepository;
+import com.soompyo.server.support.TestAuthSupport;
+import com.soompyo.server.user.domain.User;
+
+public record DiaryApiFixture(TestRestTemplate client, DiaryRepository diaryRepository,
+                              TestAuthSupport authSupport) {
+    private static final String DEFAULT_USER_EMAIL = "diary-test-user@test.com";
+    private static final String DEFAULT_USER_PASSWORD = "Password1234";
+
+    public static DiaryApiFixture create(Environment environment, DiaryRepository diaryRepository,
+        TestAuthSupport authSupport) {
+        TestRestTemplate client = new TestRestTemplate(new RestTemplateBuilder());
+        LocalHostUriTemplateHandler uriTemplateHandler = new LocalHostUriTemplateHandler(environment);
+        client.setUriTemplateHandler(uriTemplateHandler);
+        return new DiaryApiFixture(client, diaryRepository, authSupport);
+    }
+
+    public TestAuthSupport.AuthenticatedUser ensureAuthenticatedDefaultUser() {
+        TestAuthSupport.AuthenticatedUser authenticatedUser =
+            authSupport.ensureUserWithToken(DEFAULT_USER_EMAIL, DEFAULT_USER_PASSWORD);
+        authSupport.applyAuthentication(client, authenticatedUser);
+        return authenticatedUser;
+    }
+
+    public User ensureTestUser() {
+        return ensureAuthenticatedDefaultUser().user();
+    }
+
+}

--- a/src/test/java/com/soompyo/server/support/TestAuthSupport.java
+++ b/src/test/java/com/soompyo/server/support/TestAuthSupport.java
@@ -1,0 +1,87 @@
+package com.soompyo.server.support;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.lang.NonNull;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import com.soompyo.server.global.security.CustomUserDetails;
+import com.soompyo.server.global.security.JwtTokenProvider;
+import com.soompyo.server.user.domain.User;
+import com.soompyo.server.user.dto.request.UserSignUpRequestDto;
+import com.soompyo.server.user.repository.UserRepository;
+import com.soompyo.server.user.service.AuthService;
+
+public class TestAuthSupport {
+
+    private final AuthService authService;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final Map<String, AuthenticatedUser> cache = new ConcurrentHashMap<>();
+
+    public TestAuthSupport(AuthService authService, UserRepository userRepository,
+        JwtTokenProvider jwtTokenProvider) {
+        this.authService = authService;
+        this.userRepository = userRepository;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    public AuthenticatedUser ensureUserWithToken(String email, String rawPassword) {
+        return cache.compute(email, (key, existing) -> {
+            if (existing != null) {
+                return existing;
+            }
+            User user = userRepository.findByEmail(email)
+                .orElseGet(() -> registerUser(email, rawPassword));
+            String token = generateToken(user);
+            return new AuthenticatedUser(user, rawPassword, token);
+        });
+    }
+
+    private User registerUser(String email, String rawPassword) {
+        authService.signUp(new UserSignUpRequestDto(email, rawPassword));
+        return userRepository.findByEmail(email)
+            .orElseThrow(() -> new IllegalStateException("Failed to create user for tests: " + email));
+    }
+
+    private String generateToken(User user) {
+        CustomUserDetails principal = new CustomUserDetails(user,
+            List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name())));
+        return jwtTokenProvider.generateAccessToken(principal);
+    }
+
+    public void applyAuthentication(TestRestTemplate client, AuthenticatedUser user) {
+        applyAuthentication(client, user.accessToken());
+    }
+
+    public void applyAuthentication(TestRestTemplate client, String accessToken) {
+        List<ClientHttpRequestInterceptor> interceptors = client.getRestTemplate().getInterceptors();
+        interceptors.removeIf(BearerAuthInterceptor.class::isInstance);
+        interceptors.add(new BearerAuthInterceptor(accessToken));
+    }
+
+    public record AuthenticatedUser(User user, String rawPassword, String accessToken) {
+    }
+
+    private static class BearerAuthInterceptor implements ClientHttpRequestInterceptor {
+        private final String token;
+
+        private BearerAuthInterceptor(String token) {
+            this.token = token;
+        }
+
+        @Override
+        public ClientHttpResponse intercept(HttpRequest request, @NonNull byte[] body,
+            ClientHttpRequestExecution execution) throws java.io.IOException {
+            request.getHeaders().setBearerAuth(token);
+            return execution.execute(request, body);
+        }
+    }
+}

--- a/src/test/java/com/soompyo/server/user/docs/AuthDocsTest.java
+++ b/src/test/java/com/soompyo/server/user/docs/AuthDocsTest.java
@@ -17,9 +17,9 @@ import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.soompyo.server.user.UserApiTest;
+import com.soompyo.server.ApiTest;
 
-@UserApiTest
+@ApiTest
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
 @ExtendWith(RestDocumentationExtension.class)

--- a/src/test/java/com/soompyo/server/user/docs/UserDocsTest.java
+++ b/src/test/java/com/soompyo/server/user/docs/UserDocsTest.java
@@ -24,10 +24,10 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.soompyo.server.ApiTest;
 import com.soompyo.server.global.domain.UserRole;
 import com.soompyo.server.global.security.CustomUserDetails;
 import com.soompyo.server.global.security.JwtTokenProvider;
-import com.soompyo.server.user.UserApiTest;
 import com.soompyo.server.user.domain.User;
 import com.soompyo.server.user.domain.UserStatus;
 import com.soompyo.server.user.dto.response.UserDetailResponseDto;
@@ -39,7 +39,7 @@ import com.soompyo.server.user.service.UserService;
  * - PATCH /api/v1/users/me/password
  * - DELETE /api/v1/users/me
  */
-@UserApiTest
+@ApiTest
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
 @ExtendWith(RestDocumentationExtension.class)

--- a/src/test/java/com/soompyo/server/user/integrationtest/HttpCreateTest.java
+++ b/src/test/java/com/soompyo/server/user/integrationtest/HttpCreateTest.java
@@ -11,17 +11,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import com.soompyo.server.ApiTest;
 import com.soompyo.server.global.ApiResponseType;
 import com.soompyo.server.global.exception.userexception.UserLogInInformationMismatchException;
 import com.soompyo.server.global.response.ApiResponse;
 import com.soompyo.server.user.UserApiFixture;
-import com.soompyo.server.user.UserApiTest;
 import com.soompyo.server.user.dto.request.UserLoginRequestDto;
 import com.soompyo.server.user.dto.request.UserSignUpRequestDto;
 import com.soompyo.server.user.dto.response.UserLoginResponseDto;
 import com.soompyo.server.user.dto.response.UserSignUpResponseDto;
 
-@UserApiTest
+@ApiTest
 @DisplayName("사용자 생성(회원가입 및 로그인) API - POST /api/v1/users/signUp & /api/v1/users/login")
 class HttpCreateTest {
 

--- a/src/test/java/com/soompyo/server/user/integrationtest/HttpDeleteTest.java
+++ b/src/test/java/com/soompyo/server/user/integrationtest/HttpDeleteTest.java
@@ -8,11 +8,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import com.soompyo.server.ApiTest;
 import com.soompyo.server.global.response.ApiResponse;
 import com.soompyo.server.user.UserApiFixture;
-import com.soompyo.server.user.UserApiTest;
 
-@UserApiTest
+@ApiTest
 @DisplayName("사용자 삭제 API - DELETE /api/v1/users/me")
 class HttpDeleteTest {
 

--- a/src/test/java/com/soompyo/server/user/integrationtest/HttpReadTest.java
+++ b/src/test/java/com/soompyo/server/user/integrationtest/HttpReadTest.java
@@ -9,12 +9,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import com.soompyo.server.ApiTest;
 import com.soompyo.server.global.response.ApiResponse;
 import com.soompyo.server.user.UserApiFixture;
-import com.soompyo.server.user.UserApiTest;
 import com.soompyo.server.user.repository.UserRepository;
 
-@UserApiTest
+@ApiTest
 @DisplayName("사용자 조회 API - GET /api/v1/users")
 class HttpReadTest {
 

--- a/src/test/java/com/soompyo/server/user/integrationtest/HttpUpdateTest.java
+++ b/src/test/java/com/soompyo/server/user/integrationtest/HttpUpdateTest.java
@@ -10,17 +10,17 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import com.soompyo.server.ApiTest;
 import com.soompyo.server.global.ApiResponseType;
 import com.soompyo.server.global.exception.userexception.UserPasswordMismatchException;
 import com.soompyo.server.global.exception.userexception.UserPasswordUnchangedException;
 import com.soompyo.server.global.response.ApiResponse;
 import com.soompyo.server.user.UserApiFixture;
-import com.soompyo.server.user.UserApiTest;
 import com.soompyo.server.user.domain.User;
 import com.soompyo.server.user.dto.request.UserPasswordUpdateRequestDto;
 import com.soompyo.server.user.repository.UserRepository;
 
-@UserApiTest
+@ApiTest
 @DisplayName("사용자 수정 API - PATCH /api/v1/users/me/")
 class HttpUpdateTest {
     @Autowired


### PR DESCRIPTION
## 개요
- JWT 토큰에 포함된 roles 정보를 인증 컨텍스트에 정확히 반영하도록 필터 로직을 정리했습니다.
- 로그인 실패 응답이 전역 예외 정의의 상태 코드와 메시지를 그대로 따르도록 통일했습니다.
- 사용하지 않는 일기 도메인 테스트 픽스처를 제거해 테스트 컴파일 오류를 해소했습니다.

## 변경 사항
- `JwtAuthenticationFilter`가 단일 role 대신 roles 배열을 읽어 `SimpleGrantedAuthority` 목록으로 매핑
- `ApiResponse#credentialFail()`이 `UserLogInInformationMismatchException`의 상태 코드 및 메시지를 재사용
- `FixtureConfiguration`에서 일기 도메인 관련 빈과 의존성 제거, `DiaryApiFixture` 테스트 보조 클래스 삭제

## 테스트
- [x] `./gradlew test`

## 참고 사항
- 여러 권한을 가진 토큰도 정상적으로 인증 컨텍스트에 반영됩니다.
- 로그인 실패 응답이 전역 예외 정의와 일치하므로 클라이언트 단 처리 로직 수정이 필요 없습니다.
- 일기 도메인 테스트 픽스처 제거로 현재 통합 테스트 흐름에 영향이 없습니다.
