### PR TITLE
refactor(global): ApiResponse에서 code, status 필드 제거

### DIFF
--- a/src/main/java/com/soompyo/server/global/response/ApiResponse.java
+++ b/src/main/java/com/soompyo/server/global/response/ApiResponse.java
@@ -17,8 +17,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ApiResponse<T> {
     private T data;
-    private int code;
-    private String status;
     private String message;
 
     public static <T> ApiResponse<T> ok(T data) {
@@ -30,26 +28,23 @@ public class ApiResponse<T> {
     }
 
     public static <T> ApiResponse<T> of(T data, HttpStatus httpStatus) {
-        return ApiResponse.of(data, httpStatus, httpStatus.getReasonPhrase());
+        return ApiResponse.of(data, httpStatus.getReasonPhrase());
     }
 
-    public static <T> ApiResponse<T> of(T data, HttpStatus httpStatus, String message) {
-        return new ApiResponse<>(data, httpStatus.value(), httpStatus.name(), message);
+    public static <T> ApiResponse<T> of(T data, String message) {
+        return new ApiResponse<>(data, message);
     }
 
     public static ApiResponse<Void> validationFail(BusinessException exception) {
-        return new ApiResponse<>(null, exception.getHttpStatus().value(), exception.getErrorCode(),
-            exception.getMessage());
+        return new ApiResponse<>(null, exception.getMessage());
     }
 
     public static ApiResponse<List<ValidationErrorResponse>> validationFail(BindException exception) {
-        return new ApiResponse<>(ValidationErrorResponse.of(exception.getFieldErrors()), HttpStatus.BAD_REQUEST.value(),
-            HttpStatus.BAD_REQUEST.name(), "입력 값을 확인해주세요.");
+        return new ApiResponse<>(ValidationErrorResponse.of(exception.getFieldErrors()), "입력 값을 확인해주세요.");
     }
 
     public static ApiResponse<Void> credentialFail() {
         UserLogInInformationMismatchException exception = new UserLogInInformationMismatchException();
-        return new ApiResponse<>(null, exception.getHttpStatus().value(), exception.getErrorCode(),
-            exception.getMessage());
+        return new ApiResponse<>(null, exception.getMessage());
     }
 }


### PR DESCRIPTION
## Summary
- `ApiResponse`에서 `code`, `status` 필드를 제거하여 `ResponseEntity`가 HTTP 상태 코드를 전담하도록 역할 분리
- 응답 본문과 HTTP 상태 코드 간의 중복 및 불일치 가능성 제거

## Test plan
- [x] `./gradlew compileJava` 빌드 성공 확인
- [ ] 기존 API 테스트 통과 확인
- [ ] 클라이언트 측 응답 파싱 로직에 `code`, `status` 필드 의존 여부 확인